### PR TITLE
Remove fuzzing-specific fields from `test_objectt'

### DIFF
--- a/src/deepconcolic.py
+++ b/src/deepconcolic.py
@@ -32,7 +32,7 @@ def deepconcolic(criterion, norm, test_object, report_args, engine_args = {}):
       engine = nc_setup (test_object = test_object,
                          setup_analyzer = NcL0Analyzer,
                          input_shape = test_object.raw_data.data[0].shape,
-                         eval_batch = test_object.eval_batch)
+                         eval_batch = eval_batch_func (test_object.dnn))
     else:
       print('\n not supported norm... {0}\n'.format(norm))
       sys.exit(0)

--- a/src/deepconcolic.py
+++ b/src/deepconcolic.py
@@ -140,10 +140,9 @@ def main():
     print (' \n == Please specify the input neural network == \n')
     sys.exit(0)
 
+  # fuzzing_params
   if args.inputs!='-1':
-
-    file_list = [] # fuzzing_params
-
+    file_list = []
     xs=[]
     print ('Loading input data... ', end = '', flush = True)
     for path, subdirs, files in os.walk(args.inputs):
@@ -240,15 +239,13 @@ def main():
     test_object.labels=labels
 
   init_tests = int (args.init_tests) if args.init_tests is not None else None
-  # fuzzing params
-  test_object.num_tests, test_object.num_processes = int(args.num_tests), int(args.num_processes)
-  test_object.stime = int(args.stime)
-  test_object.file_list = file_list
-  test_object.model_name = args.model
-  if args.fuzzing:
-    deepconcolic_fuzz(test_object, outs)
-    sys.exit(0)
 
+  # fuzzing params
+  if args.fuzzing:
+    deepconcolic_fuzz(test_object, outs, args.model, int(args.stime), file_list,
+                      num_tests = int(args.num_tests),
+                      num_processes = int(args.num_processes))
+    sys.exit(0)
 
   test_object.check_layer_indices (criterion)
   deepconcolic (criterion, norm, test_object,

--- a/src/deepconcolic_fuzz.py
+++ b/src/deepconcolic_fuzz.py
@@ -25,7 +25,8 @@ from variables import *
 ## to be refined
 apps = ['./src/run_template.py']
 
-def deepconcolic_fuzz(test_object, outs):
+def deepconcolic_fuzz(test_object, outs, model_name, stime, file_list,
+                      num_tests = 1000, num_processes = 1):
   #report_args = { 'save_input_func': test_object.save_input_func,
   #                'inp_ub': test_object.inp_ub,
   #                'outs': outs}
@@ -39,16 +40,11 @@ def deepconcolic_fuzz(test_object, outs):
   if not os.path.isdir(adv_path):
       os.system('mkdir -p {0}'.format(adv_path))
 
-  num_tests = test_object.num_tests
-  num_processes = test_object.num_processes
-  stime = test_object.stime
-  file_list = test_object.file_list
   data = test_object.raw_data.data
   if data.shape[1] == 28: # todo: this is mnist hacking
     img_rows, img_cols, img_channels = data.shape[1], data.shape[2], 1
   else:
     img_rows, img_cols, img_channels = data.shape[1], data.shape[2], data.shape[3]
-  model_name = test_object.model_name
 
   num_crashes = 0
   for i in range(num_tests):

--- a/src/utils.py
+++ b/src/utils.py
@@ -284,6 +284,9 @@ def eval_batch(o, ims, allow_input_layer = False):
 def eval(o, im, having_input_layer = False):
   return eval_batch (o, np.array([im]), having_input_layer)
 
+def eval_batch_func (dnn):
+  return lambda imgs, **kwds: eval_batch (dnn, imgs, **kwds)
+
 # ---
 
 class raw_datat:

--- a/src/utils.py
+++ b/src/utils.py
@@ -309,12 +309,6 @@ class test_objectt:
     self.trace_flag=None
     self.layer_indices=None
     self.feature_indices=None
-
-    # fuzzing params
-    self.num_tests = None
-    self.num_processes = None
-    self.file_list = None
-    self.model_name = None
   
 
   def tests_layer(self, cl):


### PR DESCRIPTION
This change avoids cluttering the `test_objectt' data structure with
parameters that can easily be passed directly to the fuzzing engine.