### PR TITLE
Minor changes and a new option to help setting up parameters of criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The paper is available in https://arxiv.org/abs/1805.00089.
 
 ```
 usage: deepconcolic.py [-h] [--model MODEL] [--inputs DIR] --outputs DIR
-                       [--criterion nc, ssc...] [--init INT]
+                       [--criterion nc, ssc...] [--setup-only] [--init INT]
                        [--max-iterations INT] [--save-all-tests]
                        [--rng-seed SEED] [--labels FILE]
                        [--dataset {mnist,fashion_mnist,cifar10,OpenML:har}]
@@ -38,6 +38,8 @@ optional arguments:
   --outputs DIR         the outputput test data directory
   --criterion nc, ssc...
                         the test criterion
+  --setup-only          only setup the coverage critierion and analyzer, and
+                        terminate before engine initialization and startup
   --init INT            number of test samples to initialize the engine
   --max-iterations INT  maximum number of engine iterations (use < 0 for
                         unlimited)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ usage: deepconcolic.py [-h] [--model MODEL] [--inputs DIR] --outputs DIR
                        [--vgg16-model] [--filters {LOF}] [--norm linf, l0]
                        [--input-rows INT] [--input-cols INT]
                        [--input-channels INT] [--cond-ratio FLOAT]
-                       [--top-classes INT] [--layer-index INT [INT ...]]
+                       [--top-classes INT] [--layers LAYER [LAYER ...]]
                        [--feature-index INT] [--fuzzing] [--num-tests INT]
                        [--num-processes INT] [--sleep-time INT]
 
@@ -62,8 +62,8 @@ optional arguments:
   --input-channels INT  input channels
   --cond-ratio FLOAT    the condition feature size parameter (0, 1]
   --top-classes INT     check the top-xx classifications
-  --layer-index INT [INT ...]
-                        to test a particular layer
+  --layers LAYER [LAYER ...]
+                        test layers given by name or index
   --feature-index INT   to test a particular feature map
   --fuzzing             to start fuzzing
   --num-tests INT       number of tests to generate
@@ -91,7 +91,7 @@ python deepconcolic.py --model ../saved_models/cifar10_complicated.h5 --dataset 
 
 To test a particular layer
 ```
-python deepconcolic.py --model ../saved_models/cifar10_complicated.h5 --dataset cifar10 --outputs outs/ --layer-index 2
+python deepconcolic.py --model ../saved_models/cifar10_complicated.h5 --dataset cifar10 --outputs outs/ --layers 2
 ```
 
 To run MC/DC for DNNs on the CIFAR-10 model

--- a/src/deepconcolic.py
+++ b/src/deepconcolic.py
@@ -120,9 +120,8 @@ def main():
                       help="the condition feature size parameter (0, 1]", metavar="FLOAT")
   parser.add_argument("--top-classes", dest="top_classes", default="1",
                       help="check the top-xx classifications", metavar="INT")
-  parser.add_argument("--layer-index", dest="layer_indexes",
-                      nargs="+", type=int,
-                      help="to test a particular layer", metavar="INT")
+  parser.add_argument("--layers", dest="layers", nargs="+", metavar="LAYER",
+                      help="test layers given by name or index")
   parser.add_argument("--feature-index", dest="feature_index", default="-1",
                       help="to test a particular feature map", metavar="INT")
   # fuzzing params
@@ -221,12 +220,10 @@ def main():
   test_object.cond_ratio = cond_ratio
   test_object.top_classes = top_classes
   test_object.inp_ub = inp_ub
-  if args.layer_indexes is not None:
+  if args.layers is not None:
     try:
-      test_object.layer_indices=[]
-      for layer_index in tuple(args.layer_indexes):
-        layer = dnn.get_layer (index = int (layer_index))
-        test_object.layer_indices.append (dnn.layers.index (layer))
+      test_object.set_layer_indices (int (l) if l.isdigit () else l
+                                     for l in args.layers)
     except ValueError as e:
       sys.exit (e)
     if args.feature_index!='-1':

--- a/src/deepconcolic.py
+++ b/src/deepconcolic.py
@@ -82,6 +82,9 @@ def main():
   #                     help="the extra training dataset", metavar="DIR")
   parser.add_argument("--criterion", dest="criterion", default="nc",
                       help="the test criterion", metavar="nc, ssc...")
+  parser.add_argument("--setup-only", dest="setup_only", action='store_true',
+                      help="only setup the coverage critierion and analyzer, "
+                      "and terminate before engine initialization and startup")
   parser.add_argument("--init", dest="init_tests", metavar="INT",
                       help="number of test samples to initialize the engine")
   parser.add_argument("--max-iterations", dest="max_iterations", metavar="INT",
@@ -274,6 +277,7 @@ def main():
                               'LB_noise': lower_bound_metric_noise },
                 engine_args = { 'custom_filters': input_filters },
                 input_bounds = input_bounds,
+                run_engine = not args.setup_only,
                 initial_test_cases = init_tests,
                 max_iterations = max_iterations)
 

--- a/src/engine.py
+++ b/src/engine.py
@@ -458,6 +458,9 @@ class EarlyTermination (Exception):
 # ---
 
 
+_log_target_selection_level = 1
+
+
 class Criterion (_ActivationStatBasedInitializable):
   '''
   Base class for test critieria.
@@ -469,6 +472,7 @@ class Criterion (_ActivationStatBasedInitializable):
   def __init__(self,
                analyzer: Analyzer = None,
                prefer_rooted_search = None,
+               verbose: int = 1,
                **kwds):
     '''
     A criterion operates based on an `analyzer` to find new concrete
@@ -482,6 +486,7 @@ class Criterion (_ActivationStatBasedInitializable):
     super().__init__(**kwds)
     self.analyzer = analyzer
     self.test_cases = []
+    self.verbose = some (verbose, 1)
     self.rooted_search = self._rooted_search (prefer_rooted_search)
 
 
@@ -616,7 +621,8 @@ class Criterion (_ActivationStatBasedInitializable):
     '''
     if self.rooted_search:
       x0, target = self.find_next_rooted_test_target ()
-      tp1 ('| Targeting {}'.format(target))
+      if self.verbose >= _log_target_selection_level:
+        p1 (f'| Targeting {target}')
       x1_attempt = self.analyzer.search_input_close_to (x0, target)
       if x1_attempt == None:
         return None, target
@@ -625,7 +631,8 @@ class Criterion (_ActivationStatBasedInitializable):
         return (x0, x1, d), target
     else:
       target = self.find_next_test_target ()
-      tp1 ('| Targeting {}'.format(target))
+      if self.verbose >= _log_target_selection_level:
+        p1 (f'| Targeting {target}')
       attempt = self.analyzer.search_close_inputs (target)
       if attempt == None:
         return None, target

--- a/src/engine.py
+++ b/src/engine.py
@@ -749,7 +749,7 @@ class Engine:
       p1 ('Initializing with {} randomly selected test case{} that {} correctly classified.'
           .format(*s_(len (x)), is_are_(len (x))[1]))
       self.criterion.add_new_test_cases (x)
-    elif self.criterion.rooted_search:
+    elif initial_test_cases is None and self.criterion.rooted_search:
       p1 ('Randomly selecting an input from test data.')
       x = np.random.default_rng().choice (a = self.ref_data.data, axis = 0)
       report.save_input (x, 'seed-input')
@@ -785,6 +785,7 @@ class Engine:
       p1 ('Continuing tests for {}{}.'
           .format (self, '' if max_iterations < 0 else
                    ' ({} max iterations)'.format (max_iterations)))
+      initial_test_cases = initial_test_cases or 0
 
     report = report if isinstance (report, Report) else \
              report (criterion, **kwds)

--- a/src/engine.py
+++ b/src/engine.py
@@ -434,12 +434,15 @@ class Report:
     self.ntests += 1
 
 
-  def step(self, *args) -> None:
+  def step(self, *args, dry = False) -> None:
     '''
     Prints a single report line.
+
+    Do not count as new step if `dry` holds.
     '''
     append_in_file (self.report_file, *args, '\n')
-    self.nsteps += 1
+    if not dry:
+      self.nsteps += 1
 
 
 # ---
@@ -797,7 +800,8 @@ class Engine:
     p1 ('#0 {}: {.as_prop:10.8%}'.format(criterion, coverage))
     report.step ('{0}-cover: {1} #test cases: {0.num_test_cases} '
                  .format(criterion, coverage),
-                 '#adversarial examples: 0')
+                 '#adversarial examples: 0',
+                 dry = True)
 
     iteration = 1
     init_tests = report.num_tests

--- a/src/lp.py
+++ b/src/lp.py
@@ -214,7 +214,7 @@ class PulpSolver4DNN (LpSolver4DNN):
     # Draw a new distance lower bound:
     self.d_var.lowBound = metric.draw_lower_bound ()
 
-    ctp1 ('LP solving: {} constraints'.format(len(problem.constraints)))
+    tp1 ('LP solving: {} constraints'.format(len(problem.constraints)))
     assert (problem.objective is not None)
     problem.solve (self.solver)
     tp1 ('Solved!')

--- a/src/plotting.py
+++ b/src/plotting.py
@@ -1,5 +1,9 @@
 from utils import OutputDir
 import os
+mpl_backend = os.getenv ('DC_MPL_BACKEND')
+mpl_fig_width = float (os.getenv ('DC_MPL_FIG_WIDTH', default = 7.))
+mpl_fig_ratio = float (os.getenv ('DC_MPL_FIG_RATIO', default = 1))
+mpl_fig_pgf_width = float (os.getenv ('DC_MPL_FIG_PGF_WIDTH', default = 4.7))
 
 default_params = {
   'font.size': 11,
@@ -7,10 +11,13 @@ default_params = {
   'axes.unicode_minus': False,
 }
 
-pgf = os.getenv ('DC_MPL_BACKEND') in ('pgf', 'PGF')
+png = mpl_backend in ('png', 'PNG')
+png_default_figsize = (mpl_fig_width, mpl_fig_width * mpl_fig_ratio)
+
+pgf = mpl_backend in ('pgf', 'PGF')
 pgf_output_pgf = True
 pgf_output_pdf = True
-pgf_default_figsize = (4.7, 4.7)
+pgf_default_figsize = (mpl_fig_pgf_width, mpl_fig_pgf_width * mpl_fig_ratio)
 pgf_default_params = {
   'font.size': 8,
   'font.family': 'cmr10',        # lmodern
@@ -63,7 +70,8 @@ pgf_setup ()
 
 # ---
 
-def subplots (*args, figsize = pgf_default_figsize, **kwds):
+def subplots (*args, figsize = None, **kwds):
+  figsize = figsize or (pgf_default_figsize if pgf else png_default_figsize)
   if plt:
     return plt.subplots (*args, figsize = figsize, **kwds)
   else:
@@ -73,17 +81,21 @@ def subplots (*args, figsize = pgf_default_figsize, **kwds):
 
 def show (fig = None, outdir: OutputDir = None, basefilename = None):
   if plt:
-    if not pgf:
+    if not pgf and not png:
       plt.show ()
     elif fig is not None and basefilename is not None:
       plt.tight_layout (pad = 0, w_pad = 0.1, h_pad = 0.1)
       outdir = OutputDir () if outdir is None else outdir
       assert isinstance (outdir, OutputDir)
-      if pgf_output_pgf:
+      if png:
+        f = outdir.filepath (basefilename + '.png')
+        tp1 ('Outputting {}...'.format (f))
+        fig.savefig (f, format='png')
+      if pgf and pgf_output_pgf:
         f = outdir.filepath (basefilename + '.pgf')
         tp1 ('Outputting {}...'.format (f))
         fig.savefig (f, format='pgf')
-      if pgf_output_pdf:
+      if pgf and pgf_output_pdf:
         f = outdir.filepath (basefilename + '.pdf')
         tp1 ('Outputting {}...'.format (f))
         fig.savefig (f, format='pdf')

--- a/src/utils.py
+++ b/src/utils.py
@@ -213,7 +213,7 @@ def save_in_csv (filename):
       file.write (name + ' ')
       np.savetxt (file, arr, newline = ' ')
       file.write ('\n')
-      
+
     # append_in_file (f, name, ' ', np.array_str (arr, max_line_width = np.inf), '\n')
   return save_an_array
 
@@ -321,7 +321,7 @@ class raw_datat:
     self.data=data
     self.labels=labels
     self.name = name
-    
+
 
 
 class test_objectt:
@@ -339,7 +339,17 @@ class test_objectt:
     self.trace_flag=None
     self.layer_indices=None
     self.feature_indices=None
-  
+
+
+  def layer_index (self, l):
+    layer = self.dnn.get_layer (name = l) if isinstance (l, str) else \
+            self.dnn.get_layer (index = int (l))
+    return self.dnn.layers.index (layer)
+
+
+  def set_layer_indices (self, ll):
+    self.layer_indices = [ self.layer_index (l) for l in ll ]
+
 
   def tests_layer(self, cl):
     return self.layer_indices == None or cl.layer_index in self.layer_indices
@@ -408,7 +418,7 @@ def get_ssc_next(clayers, layer_indices=None, feature_indices=None):
       #sys.exit(0)
 
     tot_s = np.prod (clayers2[dec_layer_index].ssc_map.shape)
-    
+
     the_dec_pos = np.random.randint(0, tot_s)
     if not feature_indices==None:
       the_dec_pos=np.argmax(clayers2[dec_layer_index].ssc_map.shape)
@@ -419,7 +429,7 @@ def get_ssc_next(clayers, layer_indices=None, feature_indices=None):
         the_dec_pos+=1
         continue
       else:
-        found=True 
+        found=True
         break
     #if the_dec_pos>=tot_s:
     #  print ('all decision features at layer {0} have been covered'.format(dec_layer_index))


### PR DESCRIPTION
Note that none of the current coverage criteria require any parameter: the `--setup-only' options is mostly useful for tuning the BN-based abstraction (in a separate development branch).

This might still be useful for other use-cases, so I put it in the master branch.