### PR TITLE
Tuto-secific branch (breaks functionality: NOT for master branch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /docsrc/build
 # For branches other than master:
 #/docs
+/saved_models

--- a/EKiML/__init__.py
+++ b/EKiML/__init__.py
@@ -1,6 +1,4 @@
-import sys, os
-__thisdir = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert (0, os.path.join (__thisdir))
+import os
 
 # Check conda env
 assert \

--- a/GUAP/__init__.py
+++ b/GUAP/__init__.py
@@ -1,6 +1,4 @@
-import sys, os
-__thisdir = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert (0, os.path.join (__thisdir))
+import os
 
 # Check conda env
 assert \

--- a/testRNN/__init__.py
+++ b/testRNN/__init__.py
@@ -1,6 +1,4 @@
-import sys, os
-__thisdir = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert (0, os.path.join (__thisdir))
+import os
 
 # Check conda env
 assert \


### PR DESCRIPTION
This PR is NOT for the master branch.

Indeed, it brings several internal checks to be done when the tools are executed, that are intended to assess whether they are correctly executed in the context of the tutorial demonstrations. This is to help prevent some unintended uses of the tools already observed by users when testing the tutorial commands on some setups.

The idea is, if possible, to create a new branch (typically named `tuto') of off this pull request, and to use a dedicated git clone command as part for the tutorial document and slides. If this is not possible, please create this `tuto' branch out of `master', and then I'll PR on the new branch afterwards.

Thanks!